### PR TITLE
Defining of version number inside of a module ResqueDelta causes load errors

### DIFF
--- a/lib/thinking_sphinx/deltas/resque_delta/version.rb
+++ b/lib/thinking_sphinx/deltas/resque_delta/version.rb
@@ -1,6 +1,6 @@
 module ThinkingSphinx
   module Deltas
-    module ResqueDelta
+    class ResqueDeltaInfo
       VERSION = "0.0.5"
     end
   end

--- a/ts-resque-delta.gemspec
+++ b/ts-resque-delta.gemspec
@@ -4,7 +4,7 @@ require "thinking_sphinx/deltas/resque_delta/version"
 
 Gem::Specification.new do |s|
   s.name        = "ts-resque-delta"
-  s.version     = ThinkingSphinx::Deltas::ResqueDelta::VERSION
+  s.version     = ThinkingSphinx::Deltas::ResqueDeltaInfo::VERSION
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Aaron Gibralter"]
   s.email       = ["aaron.gibralter@gmail.com"]

--- a/ts-resque-delta.gemspec
+++ b/ts-resque-delta.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency "resque", "~> 1.10"
   s.add_dependency "resque-lock-timeout", "~> 0.2.1"
 
-  s.add_development_dependency "rspec", ">= 1.2.9"
+  s.add_development_dependency "rspec", "= 1.3.1"
   s.add_development_dependency "cucumber", ">= 0"
   s.add_development_dependency "database_cleaner", ">= 0.5.2"
 end


### PR DESCRIPTION
Had to rename the class/module the version constant is defined to prevent loader errors when ResqueDelta would be redefined from a  module to a class.  With bundler loading the gemspec files this would break running inside of resque-forker... I realize if someone else was depending on how VERSION was defined, this would be backwards incompatible... 
