### PR TITLE
Feature/task per index

### DIFF
--- a/lib/thinking_sphinx/deltas/resque_delta.rb
+++ b/lib/thinking_sphinx/deltas/resque_delta.rb
@@ -41,10 +41,12 @@ class ThinkingSphinx::Deltas::ResqueDelta < ThinkingSphinx::Deltas::DefaultDelta
   #
   def index(model, instance = nil)
     return true if skip?(instance)
-    Resque.enqueue(
-      ThinkingSphinx::Deltas::ResqueDelta::DeltaJob,
-      model.delta_index_names
-    )
+    model.delta_index_names.each do |delta|
+      Resque.enqueue(
+        ThinkingSphinx::Deltas::ResqueDelta::DeltaJob,
+        [delta]
+      )
+    end
     if instance
       Resque.enqueue(
         ThinkingSphinx::Deltas::ResqueDelta::FlagAsDeletedJob,

--- a/lib/thinking_sphinx/deltas/resque_delta.rb
+++ b/lib/thinking_sphinx/deltas/resque_delta.rb
@@ -42,6 +42,7 @@ class ThinkingSphinx::Deltas::ResqueDelta < ThinkingSphinx::Deltas::DefaultDelta
   def index(model, instance = nil)
     return true if skip?(instance)
     model.delta_index_names.each do |delta|
+      next if index_locked?(delta)
       Resque.enqueue(
         ThinkingSphinx::Deltas::ResqueDelta::DeltaJob,
         [delta]
@@ -69,6 +70,10 @@ class ThinkingSphinx::Deltas::ResqueDelta < ThinkingSphinx::Deltas::DefaultDelta
     !ThinkingSphinx.updates_enabled? ||
     !ThinkingSphinx.deltas_enabled?  ||
     (instance && !toggled(instance))
+  end
+
+  def index_locked?(name)
+    Resque.redis.get("ts-delta:index:#{name}:locked") == "true"
   end
 end
 

--- a/lib/thinking_sphinx/deltas/resque_delta/tasks.rb
+++ b/lib/thinking_sphinx/deltas/resque_delta/tasks.rb
@@ -44,8 +44,10 @@ namespace :thinking_sphinx do
 			ret = $?
 				Resque.redis.del("ts-delta:index:#{name}_delta:locked")
 			exit(-1) if ret.to_i != 0
-			system "indexer --config #{CONFIG_FILE} --rotate #{name}_delta"
-			exit(-1) if $?.to_i != 0
+			Resque.enqueue(
+				ThinkingSphinx::Deltas::ResqueDelta::DeltaJob,
+				["#{name}_delta"]
+			)
 		end
 	end
 end

--- a/lib/thinking_sphinx/deltas/resque_delta/tasks.rb
+++ b/lib/thinking_sphinx/deltas/resque_delta/tasks.rb
@@ -18,8 +18,7 @@ namespace :thinking_sphinx do
 	desc "Deals with large indexes one at a time with delta locking"
 	task :smart_index do
 		require 'set'
-		require 'rubygems'
-		require 'resque'
+		require 'thinking_sphinx/deltas/resque_delta'
 
 		CONFIG_FILE = ENV['CONFIG_FILE']
 

--- a/lib/thinking_sphinx/deltas/resque_delta/tasks.rb
+++ b/lib/thinking_sphinx/deltas/resque_delta/tasks.rb
@@ -14,9 +14,46 @@ namespace :thinking_sphinx do
   #     :max_priority => ENV['MAX_PRIORITY']
   #   ).start
   end
+
+	desc "Deals with large indexes one at a time with delta locking"
+	task :smart_index do
+		require 'set'
+		require 'rubygems'
+		require 'resque'
+
+		CONFIG_FILE = ENV['CONFIG_FILE']
+
+		if CONFIG_FILE.nil? && ENV['RAILS_ROOT'].nil? && ENV['RAILS_ENV'].nil?
+			raise "Either CONFIG_FILE or RAILS_ROOT and RAILS_ENV must be set!"
+		end
+
+		CONFIG_FILE ||= File.join(ENV['RAILS_ROOT'], 'config', "#{ENV['RAILS_ENV']}.sphinx.conf")
+
+		indexes_ary = `egrep "^index\ [a-zA-Z_]+_(core|delta)" #{CONFIG_FILE} | cut -c 7- | sed -e "s/ :.*//"`
+
+		indexes = SortedSet.new
+		indexes_ary.each do |index|
+			name, sep, type = index.rpartition('_')
+
+			indexes << name
+		end
+
+		indexes.each do |name|
+			Resque.redis.set("ts-delta:index:#{name}_delta:locked", 'true')
+			system "indexer --config #{CONFIG_FILE} --rotate #{name}_core"
+			ret = $?
+				Resque.redis.del("ts-delta:index:#{name}_delta:locked")
+			exit(-1) if ret.to_i != 0
+			system "indexer --config #{CONFIG_FILE} --rotate #{name}_delta"
+			exit(-1) if $?.to_i != 0
+		end
+	end
 end
 
 namespace :ts do
   desc "Process stored delta index requests"
   task :rd => "thinking_sphinx:resque_delta"
+
+	desc "Deals with large indexes one at a time with delta locking"
+	task :si => "thinking_sphinx:smart_index"
 end


### PR DESCRIPTION
Our database has grown to the point where it takes a while to index the core of some of our indexes.  The default behavior of clearing the queue and indexing everything together no longer works for us.  In response to this, I've modified your gem to create a task per index and to provide locking around the delta indexer.

Where indexing a model might create a task that indexes index1, index2, and index3 deltas, now you get three tasks that each do one of those indexes.  This makes it very easy to clear duplicates.

I've written a rake task called smart_index that parses the sphinx config to find core/delta index groups.  It then will run through these and lock the delta indexer while the core is running.  This is needed because the core index will reset the delta flag to 0 and if the delta indexer automatically runs during that time then whatever records were in the delta are now unsearchable until the core finishes.

I haven't gone so far as to toggle this behavior with a configuration value.  I wanted to get some feedback from you if you thought it would be useful to others.
