### PR TITLE
Flying Sphinx Resque Deltas

### DIFF
--- a/lib/flying_sphinx/resque_delta.rb
+++ b/lib/flying_sphinx/resque_delta.rb
@@ -1,3 +1,5 @@
+require 'thinking_sphinx/deltas/resque_delta'
+
 class FlyingSphinx::ResqueDelta < ThinkingSphinx::Deltas::ResqueDelta
   def self.job_types
     [

--- a/lib/flying_sphinx/resque_delta.rb
+++ b/lib/flying_sphinx/resque_delta.rb
@@ -1,0 +1,36 @@
+class FlyingSphinx::ResqueDelta < ThinkingSphinx::Deltas::ResqueDelta
+  def self.job_types
+    [
+      FlyingSphinx::ResqueDelta::DeltaJob,
+      FlyingSphinx::ResqueDelta::FlagAsDeletedJob
+    ]
+  end
+  
+  def self.job_prefix
+    'fs-delta'
+  end
+  
+  def index(model, instance = nil)
+    return true if skip?(instance)
+    
+    model.delta_index_names.each do |delta|
+      next if self.class.locked?(delta)
+      
+      Resque.enqueue(
+        FlyingSphinx::ResqueDelta::DeltaJob,
+        [delta]
+      )
+    end
+    
+    Resque.enqueue(
+      FlyingSphinx::ResqueDelta::FlagAsDeletedJob,
+      model.core_index_names,
+      instance.sphinx_document_id
+    ) if instance
+    
+    true
+  end
+end
+
+require 'flying_sphinx/resque_delta/delta_job'
+require 'flying_sphinx/resque_delta/flag_as_deleted_job'

--- a/lib/flying_sphinx/resque_delta/delta_job.rb
+++ b/lib/flying_sphinx/resque_delta/delta_job.rb
@@ -1,0 +1,14 @@
+class FlyingSphinx::ResqueDelta::DeltaJob < ThinkingSphinx::Deltas::ResqueDelta::DeltaJob
+  @queue = :fs_delta
+  
+  # Runs Sphinx's indexer tool to process the index. Currently assumes Sphinx
+  # is running.
+  #
+  # @param [String] index the name of the Sphinx index
+  #
+  def self.perform(indices)
+    return if skip?(indices)
+
+    FlyingSphinx::IndexRequest.new(indices).perform
+  end
+end

--- a/lib/flying_sphinx/resque_delta/flag_as_deleted_job.rb
+++ b/lib/flying_sphinx/resque_delta/flag_as_deleted_job.rb
@@ -1,5 +1,5 @@
 class FlyingSphinx::ResqueDelta::FlagAsDeletedJob
-  @queue = :ts_delta
+  @queue = :fs_delta
   
   def self.perform(indices, document_id)
     FlyingSphinx::FlagAsDeletedJob.new(indices, document_id).perform

--- a/lib/flying_sphinx/resque_delta/flag_as_deleted_job.rb
+++ b/lib/flying_sphinx/resque_delta/flag_as_deleted_job.rb
@@ -1,0 +1,7 @@
+class FlyingSphinx::ResqueDelta::FlagAsDeletedJob
+  @queue = :ts_delta
+  
+  def self.perform(indices, document_id)
+    FlyingSphinx::FlagAsDeletedJob.new(indices, document_id).perform
+  end
+end

--- a/spec/flying_sphinx/resque_delta/delta_job_spec.rb
+++ b/spec/flying_sphinx/resque_delta/delta_job_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe FlyingSphinx::ResqueDelta::DeltaJob do
+  describe '@queue' do
+    it "uses the fs_delta queue" do
+      FlyingSphinx::ResqueDelta::DeltaJob.instance_variable_get(:@queue).
+        should == :fs_delta
+    end
+  end
+  
+  describe '.perform' do
+    it "doesn't create an index request when skipping" do
+      FlyingSphinx::ResqueDelta::DeltaJob.stub!(:skip? => true)
+      
+      FlyingSphinx::IndexRequest.should_not_receive(:new)
+      
+      FlyingSphinx::ResqueDelta::DeltaJob.perform ['foo_delta']
+    end
+    
+    it "performs an index request when not skipping" do
+      request = double('index request', :perform => true)
+      FlyingSphinx::ResqueDelta::DeltaJob.stub!(:skip? => false)
+      
+      FlyingSphinx::IndexRequest.should_receive(:new).
+        with(['foo_delta']).
+        and_return(request)
+      request.should_receive(:perform)
+      
+      FlyingSphinx::ResqueDelta::DeltaJob.perform ['foo_delta']
+    end
+  end
+end

--- a/spec/flying_sphinx/resque_delta/flag_as_deleted_job_spec.rb
+++ b/spec/flying_sphinx/resque_delta/flag_as_deleted_job_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe FlyingSphinx::ResqueDelta::FlagAsDeletedJob do
+  describe '@queue' do
+    it "uses the fs_delta queue" do
+      FlyingSphinx::ResqueDelta::FlagAsDeletedJob.
+        instance_variable_get(:@queue).should == :fs_delta
+    end
+  end
+  
+  describe '.perform' do
+    it "performs a flag-as-deleted job" do
+      job = double('flag as deleted job', :perform => true)
+      
+      FlyingSphinx::FlagAsDeletedJob.should_receive(:new).
+        with(['foo_core'], 5).
+        and_return(job)
+      job.should_receive(:perform)
+      
+      FlyingSphinx::ResqueDelta::FlagAsDeletedJob.perform ['foo_core'], 5
+    end
+  end
+end

--- a/spec/flying_sphinx/resque_delta_spec.rb
+++ b/spec/flying_sphinx/resque_delta_spec.rb
@@ -1,0 +1,131 @@
+require 'spec_helper'
+
+describe FlyingSphinx::ResqueDelta do
+  describe '.job_types' do
+    it "contains just the Flying Sphinx delta and delete jobs" do
+      FlyingSphinx::ResqueDelta.job_types.should == [
+        FlyingSphinx::ResqueDelta::DeltaJob,
+        FlyingSphinx::ResqueDelta::FlagAsDeletedJob
+      ]
+    end
+  end
+  
+  describe '.job_prefix' do
+    it "is fs-delta" do
+      FlyingSphinx::ResqueDelta.job_prefix.should == 'fs-delta'
+    end
+  end
+  
+  describe '#index' do
+    before :each do
+      ThinkingSphinx.updates_enabled = true
+      ThinkingSphinx.deltas_enabled  = true
+
+      Resque.stub(:enqueue => true)
+
+      @delayed_delta = FlyingSphinx::ResqueDelta.new(
+        stub('instance'), {}
+      )
+      @delayed_delta.stub(:toggled).and_return(true)
+
+      FlyingSphinx::ResqueDelta.stub(:lock)
+      FlyingSphinx::ResqueDelta.stub(:unlock)
+      FlyingSphinx::ResqueDelta.stub(:locked?).and_return(false)
+
+      @model = stub('foo')
+      @model.stub(:core_index_names  => ['foo_core'])
+      @model.stub(:delta_index_names => ['foo_delta'])
+
+      @instance = stub('instance')
+      @instance.stub(:sphinx_document_id => 42)
+    end
+
+    context 'updates disabled' do
+      before :each do
+        ThinkingSphinx.updates_enabled = false
+      end
+
+      it "should not enqueue a delta job" do
+        Resque.should_not_receive(:enqueue)
+        @delayed_delta.index(@model)
+      end
+
+      it "should not enqueue a flag as deleted job" do
+        Resque.should_not_receive(:enqueue)
+        @delayed_delta.index(@model)
+      end
+    end
+
+    context 'deltas disabled' do
+      before :each do
+        ThinkingSphinx.deltas_enabled = false
+      end
+
+      it "should not enqueue a delta job" do
+        Resque.should_not_receive(:enqueue)
+        @delayed_delta.index(@model)
+      end
+
+      it "should not enqueue a flag as deleted job" do
+        Resque.should_not_receive(:enqueue)
+        @delayed_delta.index(@model)
+      end
+    end
+
+    context "instance isn't toggled" do
+      before :each do
+        @delayed_delta.stub(:toggled => false)
+      end
+
+      it "should not enqueue a delta job" do
+        Resque.should_not_receive(:enqueue)
+        @delayed_delta.index(@model, @instance)
+      end
+
+      it "should not enqueue a flag as deleted job" do
+        Resque.should_not_receive(:enqueue)
+        @delayed_delta.index(@model, @instance)
+      end
+    end
+
+    it "should enqueue a delta job" do
+      Resque.should_receive(:enqueue).at_least(:once).with(
+        FlyingSphinx::ResqueDelta::DeltaJob,
+        ['foo_delta']
+      )
+      @delayed_delta.index(@model)
+    end
+
+    it "should enqueue a flag-as-deleted job" do
+      Resque.should_receive(:enqueue).at_least(:once).with(
+        FlyingSphinx::ResqueDelta::FlagAsDeletedJob,
+        ['foo_core'],
+        42
+      )
+      @delayed_delta.index(@model, @instance)
+    end
+
+    context "delta index is locked" do
+      before :each do
+        FlyingSphinx::ResqueDelta.stub(:locked?).and_return(true)
+      end
+
+      it "should not enqueue a delta job" do
+        Resque.should_not_receive(:enqueue).with(
+          FlyingSphinx::ResqueDelta::DeltaJob,
+          ['foo_delta']
+        )
+        @delayed_delta.index(@model, @instance)
+      end
+
+      it "should enqueue a flag-as-deleted job" do
+        Resque.should_receive(:enqueue).at_least(:once).with(
+          FlyingSphinx::ResqueDelta::FlagAsDeletedJob,
+          ['foo_core'],
+          42
+        )
+        @delayed_delta.index(@model, @instance)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,3 +5,5 @@ require 'spec/autorun'
 
 require 'thinking_sphinx'
 require 'thinking_sphinx/deltas/resque_delta'
+require 'flying_sphinx'
+require 'flying_sphinx/resque_delta'

--- a/ts-resque-delta.gemspec
+++ b/ts-resque-delta.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "0.8.7"
   s.add_development_dependency "ruby-debug"
   s.add_development_dependency "activerecord", "~> 2.3.11"
+  s.add_development_dependency "flying-sphinx", ">= 0.5.1"
 end


### PR DESCRIPTION
Hi Aaron

As you may have noticed from other emails, I've whipped up resque delta support for Flying Sphinx (a Sphinx/Thinking Sphinx add-on for Heroku I run). It's a little different to the standard delta approaches, as the Sphinx command line tools aren't available, so the `flying-sphinx` gem does the hard work.

It'd be great if you could merge this in! If there's anything missing or unclear, let me know.

Thanks

Pat
