### PR TITLE
rake thinking_sphinx:smart_index needs TS >= 1.4.1

### DIFF
--- a/ts-resque-delta.gemspec
+++ b/ts-resque-delta.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "thinking-sphinx", ">= 1.3.6"
+  s.add_dependency "thinking-sphinx", ">= 1.4.1"
   s.add_dependency "resque", "~> 1.10"
   s.add_dependency "resque-lock-timeout", "~> 0.3.1"
 


### PR DESCRIPTION
`rake ts:si` needs thinking-sphinx >= 1.4.1, otherwise a

```
rake aborted!
undefined method `generate' for #<ThinkingSphinx::Configuration:0x101010101>
```

will be raised.
