### PR TITLE
Don't enqueue duplicate jobs.

### DIFF
--- a/lib/thinking_sphinx/deltas/resque_delta/delta_job.rb
+++ b/lib/thinking_sphinx/deltas/resque_delta/delta_job.rb
@@ -1,10 +1,12 @@
 require 'resque-lock-timeout'
+require 'resque-loner'
 
 # A simple job class that processes a given index.
 #
 class ThinkingSphinx::Deltas::ResqueDelta::DeltaJob
 
   extend Resque::Plugins::LockTimeout
+  include Resque::Plugins::UniqueJob
   @queue = :ts_delta
   @lock_timeout = 240
 

--- a/lib/thinking_sphinx/deltas/resque_delta/flag_as_deleted_job.rb
+++ b/lib/thinking_sphinx/deltas/resque_delta/flag_as_deleted_job.rb
@@ -1,8 +1,10 @@
+require 'resque-loner'
 # A simple job for flagging a specified Sphinx document in a given index as
 # 'deleted'.
 #  
 class ThinkingSphinx::Deltas::ResqueDelta::FlagAsDeletedJob
 
+  include Resque::Plugins::UniqueJob
   @queue = :ts_delta
 
   # Takes an index name and document id. Please note that the document id is

--- a/ts-resque-delta.gemspec
+++ b/ts-resque-delta.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "thinking-sphinx", ">= 1.4.1"
   s.add_dependency "resque", "~> 1.10"
   s.add_dependency "resque-lock-timeout", "~> 0.3.1"
+  s.add_dependency "ryansch-resque-loner", "~> 1.0.1.2"
 
   s.add_development_dependency "rspec", "~> 1.0"
   s.add_development_dependency "cucumber", ">= 0"
@@ -30,4 +31,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "0.8.7"
   s.add_development_dependency "activerecord", "~> 2.3.11"
   s.add_development_dependency "flying-sphinx", ">= 0.5.1"
+  s.add_development_dependency "mock_redis", "~> 0.2.0"
 end


### PR DESCRIPTION
This leverages a fork of resque-loner to prevent duplicate jobs from making it into the queue.

I had to modify resque-loner to bring it up to date.  Hopefully my changes will be accepted upstream and we can drop the use of my fork.  I'm going to be testing this in production over the next few days to make sure there are no performance issues.
