### PR TITLE
Moving back to upstream mock_redis

### DIFF
--- a/ts-resque-delta.gemspec
+++ b/ts-resque-delta.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", ">= 0.8.7"
   s.add_development_dependency "activerecord", "~> 2.3.11"
   s.add_development_dependency "flying-sphinx", ">= 0.5.1"
-  s.add_development_dependency "ryansch-mock_redis", "~> 0.3.0"
+  s.add_development_dependency "mock_redis", "~> 0.3.0"
   s.add_development_dependency "guard", "~> 0.8.8"
   s.add_development_dependency "guard-rspec", "~> 0.5.8"
   s.add_development_dependency "guard-bundler", "~> 0.1.3"


### PR DESCRIPTION
This moves us from ryansch-mock_redis back to the official gem.  We were just waiting for 0.3.0 to get pushed to rubygems.
