### PR TITLE
Fixing Flying Sphinx deltas.

### DIFF
--- a/lib/flying_sphinx/resque_delta.rb
+++ b/lib/flying_sphinx/resque_delta.rb
@@ -7,29 +7,26 @@ class FlyingSphinx::ResqueDelta < ThinkingSphinx::Deltas::ResqueDelta
       FlyingSphinx::ResqueDelta::FlagAsDeletedJob
     ]
   end
-  
+
   def self.job_prefix
     'fs-delta'
   end
-  
+
   def index(model, instance = nil)
     return true if skip?(instance)
-    
+
     model.delta_index_names.each do |delta|
       next if self.class.locked?(delta)
-      
-      Resque.enqueue(
-        FlyingSphinx::ResqueDelta::DeltaJob,
-        [delta]
-      )
+
+      Resque.enqueue FlyingSphinx::ResqueDelta::DeltaJob, delta
     end
-    
+
     Resque.enqueue(
       FlyingSphinx::ResqueDelta::FlagAsDeletedJob,
       model.core_index_names,
       instance.sphinx_document_id
     ) if instance
-    
+
     true
   end
 end

--- a/lib/flying_sphinx/resque_delta/delta_job.rb
+++ b/lib/flying_sphinx/resque_delta/delta_job.rb
@@ -1,6 +1,6 @@
 class FlyingSphinx::ResqueDelta::DeltaJob < ThinkingSphinx::Deltas::ResqueDelta::DeltaJob
   @queue = :fs_delta
-  
+
   # Runs Sphinx's indexer tool to process the index. Currently assumes Sphinx
   # is running.
   #
@@ -9,6 +9,6 @@ class FlyingSphinx::ResqueDelta::DeltaJob < ThinkingSphinx::Deltas::ResqueDelta:
   def self.perform(indices)
     return if skip?(indices)
 
-    FlyingSphinx::IndexRequest.new(indices).perform
+    FlyingSphinx::IndexRequest.new([indices]).perform
   end
 end

--- a/spec/flying_sphinx/resque_delta/delta_job_spec.rb
+++ b/spec/flying_sphinx/resque_delta/delta_job_spec.rb
@@ -7,26 +7,26 @@ describe FlyingSphinx::ResqueDelta::DeltaJob do
         should == :fs_delta
     end
   end
-  
+
   describe '.perform' do
     it "doesn't create an index request when skipping" do
       FlyingSphinx::ResqueDelta::DeltaJob.stub!(:skip? => true)
-      
+
       FlyingSphinx::IndexRequest.should_not_receive(:new)
-      
-      FlyingSphinx::ResqueDelta::DeltaJob.perform ['foo_delta']
+
+      FlyingSphinx::ResqueDelta::DeltaJob.perform 'foo_delta'
     end
-    
+
     it "performs an index request when not skipping" do
       request = double('index request', :perform => true)
       FlyingSphinx::ResqueDelta::DeltaJob.stub!(:skip? => false)
-      
+
       FlyingSphinx::IndexRequest.should_receive(:new).
         with(['foo_delta']).
         and_return(request)
       request.should_receive(:perform)
-      
-      FlyingSphinx::ResqueDelta::DeltaJob.perform ['foo_delta']
+
+      FlyingSphinx::ResqueDelta::DeltaJob.perform 'foo_delta'
     end
   end
 end

--- a/spec/flying_sphinx/resque_delta_spec.rb
+++ b/spec/flying_sphinx/resque_delta_spec.rb
@@ -9,13 +9,13 @@ describe FlyingSphinx::ResqueDelta do
       ]
     end
   end
-  
+
   describe '.job_prefix' do
     it "is fs-delta" do
       FlyingSphinx::ResqueDelta.job_prefix.should == 'fs-delta'
     end
   end
-  
+
   describe '#index' do
     before :each do
       ThinkingSphinx.updates_enabled = true
@@ -90,8 +90,7 @@ describe FlyingSphinx::ResqueDelta do
 
     it "should enqueue a delta job" do
       Resque.should_receive(:enqueue).at_least(:once).with(
-        FlyingSphinx::ResqueDelta::DeltaJob,
-        ['foo_delta']
+        FlyingSphinx::ResqueDelta::DeltaJob, 'foo_delta'
       )
       @delayed_delta.index(@model)
     end


### PR DESCRIPTION
Just a quick fix for the Flying Sphinx delta - the `around_perform_lock1` method was expecting a single value as the argument, not an array.
