### PR TITLE
Automatic loading of FlyingSphinx delta

### DIFF
--- a/lib/ts-resque-delta.rb
+++ b/lib/ts-resque-delta.rb
@@ -1,2 +1,3 @@
 require 'thinking_sphinx/deltas/resque_delta'
+require 'flying_sphinx/resque_delta' if defined?(FlyingSphinx)
 require 'thinking_sphinx/deltas/resque_delta/railtie' if defined?(Rails::Railtie)


### PR DESCRIPTION
Currently, simply requiring the gem in the Gemfile does not automatically enable FlyingSphinx::ResqueDelta. I was getting undefined constants for FlyingSphinx::ResqueDelta when trying to use it as the delta.

I think it should be that simple, and this one line change makes it so.
